### PR TITLE
Do not throw an exception directly when checking for updates failed

### DIFF
--- a/utils/src/main/java/net/elytrium/commons/utils/updates/UpdatesChecker.java
+++ b/utils/src/main/java/net/elytrium/commons/utils/updates/UpdatesChecker.java
@@ -44,7 +44,9 @@ public class UpdatesChecker {
       connection.setReadTimeout(timeout);
       return checkVersion(new Scanner(connection.getInputStream(), "UTF-8").nextLine().trim(), currentVersion);
     } catch (IOException e) {
-      throw new UncheckedIOException("Unable to check for updates.", e);
+      // throw new UncheckedIOException("Unable to check for updates.", e);
+      // Do not throw an exception directly without catching it, OK?
+      return true;
     }
   }
 


### PR DESCRIPTION
The plugin can't be loaded when checking failed