### PR TITLE
Позволить загружать конфиг из корневой директории если произошла ошибка

### DIFF
--- a/config/src/main/java/net/elytrium/commons/config/YamlConfig.java
+++ b/config/src/main/java/net/elytrium/commons/config/YamlConfig.java
@@ -165,7 +165,7 @@ public class YamlConfig {
       try {
         Path parent = configFile.getParent();
         if (parent == null) {
-          throw new NullPointerException("Config parent path is null for " + configFile);
+          parent = new File("").toPath();
         }
 
         String newFileName = configFile.getFileName() + "_invalid_" + now;
@@ -262,7 +262,7 @@ public class YamlConfig {
           if (configFile != null) {
             Path parent = configFile.getParent();
             if (parent == null) {
-              throw new NullPointerException("Config parent path is null for " + configFile);
+              parent = new File("").toPath();
             }
 
             Path configFileBackup = parent.resolve(configFile.getFileName() + "_backup_" + now);


### PR DESCRIPTION
Сейчас метод load бросает NPE если не находит родительскую директорию при попытке сделать бэкап конфига.
Однако в этом мало смысла поскольку в таком случае можно просто получить текущую корневую директорию и в нее же скопировать файл. 
Это исправляет ситуацию когда конфиг из корневой директории не делал бэкап и переставал загружаться, если произошла ошибка загрузки.